### PR TITLE
strip [ci skip] from commit descriptions to not interfere with pipelines

### DIFF
--- a/src/gitlab.js
+++ b/src/gitlab.js
@@ -115,7 +115,7 @@ export default class GitLab {
                 author_name: authorName,
                 title
             }) => (
-                `- ${authorName}- [${title}](https://${this.host}/${this.org}/${repo}/commit/${id})` // eslint-disable-line camelcase
+                `- ${authorName} - [${title.replace(' [ci skip]', '')}](https://${this.host}/${this.org}/${repo}/commit/${id})` // eslint-disable-line camelcase
             )).reverse().join('\n')
         ].join('\n\n')));
     }


### PR DESCRIPTION
if the Up To Code changeset includes commits that had been marked `[ci skip]` in their respective repos, strip them here so they don't unintentionally skip the pipeline for the consuming merge to master
