### PR TITLE
Update gitlab api calls to v4

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,6 @@
+{
+    "search.exclude": {
+        "**/node_modules": true,
+        "repos/**": true
+    }
+}

--- a/src/gitlab.js
+++ b/src/gitlab.js
@@ -31,7 +31,7 @@ export default class GitLab {
             baseUrl: url.format({
                 protocol: 'https:',
                 host,
-                pathname: '/api/v3'
+                pathname: '/api/v4'
             }),
             headers: {
                 'PRIVATE-TOKEN': token
@@ -132,9 +132,9 @@ export default class GitLab {
                     this.api({
                         logger,
                         cached: true,
-                        uri: `/projects/${id}/repository/blobs/master`,
+                        uri: `/projects/${id}/repository/files/package.json/raw`,
                         qs: {
-                            filepath: 'package.json'
+                            ref: 'master'
                         }
                     })
                 )).then(({ dependencies = {}, devDependencies = {}, peerDependencies = {} }) => (

--- a/src/index.js
+++ b/src/index.js
@@ -82,6 +82,7 @@ const updateGithubRepoDependency = decorateFunctionLogger(({
             gitlabToken,
             logger
         })
+        .catch(() => '')
     )).then(body => (
         Q.fcall(() => {
             logger.trace('commit');
@@ -146,6 +147,7 @@ export const updateGitlabRepoDependency = decorateFunctionLogger(({
                 gitlabToken,
                 logger
             })
+            .catch(() => '')
         )).then(description => (
             Q.fcall(() => {
                 logger.trace('diff');


### PR DESCRIPTION
Gitlab API v3 introduced breaking change to the API for fetching raw files.

https://docs.gitlab.com/ee/api/v3_to_v4.html

Also, added a catch when trying to create the MR description, since that would fail when an external module is provided.